### PR TITLE
Fix wasm issue with multiple instantiation

### DIFF
--- a/src/svgbob-wasm/index.js
+++ b/src/svgbob-wasm/index.js
@@ -6,24 +6,29 @@ import {
 } from "./svgbob_wasm_bg.js";
 import wasmText from './base64File.js';
 
+const text = atob(wasmText);
+const bytes = new Uint8Array(text.length);
+for (let i = 0; i < text.length; i++) {
+  bytes[i] = text.charCodeAt(i);
+}
+
+const wasm = WebAssembly.instantiate(bytes, {
+  "./svgbob_wasm_bg.js": {
+    __wbindgen_object_drop_ref,
+    __wbindgen_throw,
+  },
+});
+
 let hasLoaded = false;
+wasm.then(({ instance }) => {
+  __wbg_set_wasm(instance.exports);
+  hasLoaded = true;
+});
 
 export const getRenderer = async () => {
   if (hasLoaded) return render;
 
-  const text = atob(wasmText);
-  const bytes = new Uint8Array(text.length);
-  for (let i = 0; i < text.length; i++) {
-    bytes[i] = text.charCodeAt(i);
-  }
-  
-  const wasm = await WebAssembly.instantiate(bytes, {
-    "./svgbob_wasm_bg.js": {
-      __wbindgen_object_drop_ref,
-      __wbindgen_throw,
-    },
-  });
-  __wbg_set_wasm(wasm.instance.exports);
+  await wasm;
   
   return render;
 };

--- a/tests/code.test.ts
+++ b/tests/code.test.ts
@@ -22,3 +22,11 @@ Use a code block with the language \`svgbob\`
   console.log(result.toString());
   expect(result.toString()).toContain(content);
 });
+
+test('works fine with multiple calls', async () => {
+  const processor = remark().use(svgBobCode);
+  await processor.process(`\`\`\`svgbob\nn\n\`\`\``);
+  await processor.process(`\`\`\`svgbob\ni\n\`\`\``);
+  await processor.process(`\`\`\`svgbob\nc\n\`\`\``);
+  await processor.process(`\`\`\`svgbob\ne\n\`\`\``);
+})


### PR DESCRIPTION
This was all we needed to fix it, it seems!

I've moved all code outside of the function call itself so there's no chance for multiple calls to somehow result in multiple instantiations of the same wasm binary.

The test I added would not pass on the old version.

Closes https://github.com/kdheepak/remark-svgbob/issues/3