### PR TITLE
Inline SVG in html document

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,15 @@ remark()
   });
 ```
 
+Styling for the SVG has been moved to an external css file so that it can easly be modified to meet
+your requirements.  The vanilla css is included in `src/svgbob.css`.  You will need to include this
+stylesheet in your project, otherwise you will be presented with a black box instead of your SVG.
+
+The benifit of doing this is if for example you have a dark mode setting on your site, with the
+foreground color being set by a css var, you can easily style the SVG to respond to the forground
+var.
+
+
 Then write markdown 
 
 ````markdown
@@ -69,9 +78,6 @@ Use a code block with the language `svgbob`
 
 <span><svg xmlns="http://www.w3.org/2000/svg" width="136" height="112">
     <style>
-        line, path, circle, rect, polygon{stroke:black;stroke-width:2;stroke-opacity:1;fill-opacity:1;stroke-linecap:round;stroke-linejoin:miter;}text{font-family:Iosevka Fixed, monospace;font-size:14px;}rect.backdrop{stroke:none;fill:transparent;}.broken{stroke-dasharray:8;}.filled{fill:black;}.bg_filled{fill:transparent;}.nofill{fill:transparent;}.end_marked_arrow{marker-end:url(#arrow);}.start_marked_arrow{marker-start:url(#arrow);}.end_marked_diamond{marker-end:url(#diamond);}.start_marked_diamond{marker-start:url(#diamond);}.end_marked_circle{marker-end:url(#circle);}.start_marked_circle{marker-start:url(#circle);}.end_marked_open_circle{marker-end:url(#open_circle);}.start_marked_open_circle{marker-start:url(#open_circle);}.end_marked_big_open_circle{marker-end:url(#big_open_circle);}.start_marked_big_open_circle{marker-start:url(#big_open_circle);}
-        <!--separator-->
-
     </style>
     <defs>
         <marker id="arrow" viewBox="-2 -2 8 8" refX="4" refY="2" markerWidth="7" markerHeight="7" orient="auto-start-reverse">

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,14 @@
                         "version": "1.1.1",
                         "license": "MIT",
                         "dependencies": {
-                                "remark-mdx": "^3.1.0",
                                 "unist-util-visit": "^5.0.0"
                         },
                         "devDependencies": {
+                                "css-tree": "3.1.0",
+                                "hast-util-from-html": "^2.0.0",
+                                "mdast-util-mdx-jsx": "^3.1.0",
                                 "remark": "^15.0.1",
+                                "remark-mdx": "^3.1.0",
                                 "ts-node": "^10.9.2",
                                 "tsup": "^8.0.2",
                                 "typescript": "^5.4.2",
@@ -736,6 +739,7 @@
                         "version": "4.0.6",
                         "resolved": "https://registry.npmjs.org/@types/acorn/-/acorn-4.0.6.tgz",
                         "integrity": "sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==",
+                        "dev": true,
                         "license": "MIT",
                         "dependencies": {
                                 "@types/estree": "*"
@@ -745,6 +749,7 @@
                         "version": "4.1.12",
                         "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
                         "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+                        "dev": true,
                         "dependencies": {
                                 "@types/ms": "*"
                         }
@@ -752,12 +757,14 @@
                 "node_modules/@types/estree": {
                         "version": "1.0.5",
                         "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-                        "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
+                        "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+                        "dev": true
                 },
                 "node_modules/@types/estree-jsx": {
                         "version": "1.0.5",
                         "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
                         "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+                        "dev": true,
                         "license": "MIT",
                         "dependencies": {
                                 "@types/estree": "*"
@@ -767,6 +774,7 @@
                         "version": "3.0.4",
                         "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
                         "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+                        "dev": true,
                         "license": "MIT",
                         "dependencies": {
                                 "@types/unist": "*"
@@ -776,6 +784,7 @@
                         "version": "4.0.3",
                         "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
                         "integrity": "sha512-LsjtqsyF+d2/yFOYaN22dHZI1Cpwkrj+g06G8+qtUKlhovPW89YhqSnfKtMbkgmEtYpH2gydRNULd6y8mciAFg==",
+                        "dev": true,
                         "dependencies": {
                                 "@types/unist": "*"
                         }
@@ -783,7 +792,8 @@
                 "node_modules/@types/ms": {
                         "version": "0.7.34",
                         "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.34.tgz",
-                        "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
+                        "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==",
+                        "dev": true
                 },
                 "node_modules/@types/node": {
                         "version": "20.11.25",
@@ -900,6 +910,7 @@
                         "version": "8.11.3",
                         "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
                         "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+                        "dev": true,
                         "bin": {
                                 "acorn": "bin/acorn"
                         },
@@ -911,6 +922,7 @@
                         "version": "5.3.2",
                         "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
                         "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+                        "dev": true,
                         "license": "MIT",
                         "peerDependencies": {
                                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -1066,6 +1078,7 @@
                         "version": "2.0.1",
                         "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
                         "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+                        "dev": true,
                         "license": "MIT",
                         "funding": {
                                 "type": "github",
@@ -1094,6 +1107,7 @@
                         "version": "2.0.2",
                         "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
                         "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+                        "dev": true,
                         "funding": {
                                 "type": "github",
                                 "url": "https://github.com/sponsors/wooorm"
@@ -1103,6 +1117,7 @@
                         "version": "2.1.0",
                         "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
                         "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+                        "dev": true,
                         "license": "MIT",
                         "funding": {
                                 "type": "github",
@@ -1113,6 +1128,7 @@
                         "version": "3.0.0",
                         "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
                         "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+                        "dev": true,
                         "license": "MIT",
                         "funding": {
                                 "type": "github",
@@ -1123,6 +1139,7 @@
                         "version": "2.0.1",
                         "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
                         "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+                        "dev": true,
                         "license": "MIT",
                         "funding": {
                                 "type": "github",
@@ -1183,6 +1200,17 @@
                         "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
                         "dev": true
                 },
+                "node_modules/comma-separated-tokens": {
+                        "version": "2.0.3",
+                        "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+                        "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+                        "dev": true,
+                        "license": "MIT",
+                        "funding": {
+                                "type": "github",
+                                "url": "https://github.com/sponsors/wooorm"
+                        }
+                },
                 "node_modules/commander": {
                         "version": "4.1.1",
                         "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -1212,10 +1240,25 @@
                                 "node": ">= 8"
                         }
                 },
+                "node_modules/css-tree": {
+                        "version": "3.1.0",
+                        "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+                        "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+                        "dev": true,
+                        "license": "MIT",
+                        "dependencies": {
+                                "mdn-data": "2.12.2",
+                                "source-map-js": "^1.0.1"
+                        },
+                        "engines": {
+                                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+                        }
+                },
                 "node_modules/debug": {
                         "version": "4.3.4",
                         "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
                         "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+                        "dev": true,
                         "dependencies": {
                                 "ms": "2.1.2"
                         },
@@ -1232,6 +1275,7 @@
                         "version": "1.0.2",
                         "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz",
                         "integrity": "sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==",
+                        "dev": true,
                         "dependencies": {
                                 "character-entities": "^2.0.0"
                         },
@@ -1256,6 +1300,7 @@
                         "version": "2.0.3",
                         "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
                         "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+                        "dev": true,
                         "engines": {
                                 "node": ">=6"
                         }
@@ -1264,6 +1309,7 @@
                         "version": "1.1.0",
                         "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
                         "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+                        "dev": true,
                         "dependencies": {
                                 "dequal": "^2.0.0"
                         },
@@ -1314,6 +1360,19 @@
                         "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
                         "dev": true
                 },
+                "node_modules/entities": {
+                        "version": "4.5.0",
+                        "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+                        "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+                        "dev": true,
+                        "license": "BSD-2-Clause",
+                        "engines": {
+                                "node": ">=0.12"
+                        },
+                        "funding": {
+                                "url": "https://github.com/fb55/entities?sponsor=1"
+                        }
+                },
                 "node_modules/esbuild": {
                         "version": "0.19.12",
                         "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.12.tgz",
@@ -1356,6 +1415,7 @@
                         "version": "3.0.0",
                         "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
                         "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+                        "dev": true,
                         "license": "MIT",
                         "funding": {
                                 "type": "opencollective",
@@ -1366,6 +1426,7 @@
                         "version": "2.0.0",
                         "resolved": "https://registry.npmjs.org/estree-util-visit/-/estree-util-visit-2.0.0.tgz",
                         "integrity": "sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww==",
+                        "dev": true,
                         "license": "MIT",
                         "dependencies": {
                                 "@types/estree-jsx": "^1.0.0",
@@ -1568,6 +1629,78 @@
                                 "url": "https://github.com/sponsors/sindresorhus"
                         }
                 },
+                "node_modules/hast-util-from-html": {
+                        "version": "2.0.3",
+                        "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+                        "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+                        "dev": true,
+                        "license": "MIT",
+                        "dependencies": {
+                                "@types/hast": "^3.0.0",
+                                "devlop": "^1.1.0",
+                                "hast-util-from-parse5": "^8.0.0",
+                                "parse5": "^7.0.0",
+                                "vfile": "^6.0.0",
+                                "vfile-message": "^4.0.0"
+                        },
+                        "funding": {
+                                "type": "opencollective",
+                                "url": "https://opencollective.com/unified"
+                        }
+                },
+                "node_modules/hast-util-from-parse5": {
+                        "version": "8.0.2",
+                        "resolved": "https://registry.npmjs.org/hast-util-from-parse5/-/hast-util-from-parse5-8.0.2.tgz",
+                        "integrity": "sha512-SfMzfdAi/zAoZ1KkFEyyeXBn7u/ShQrfd675ZEE9M3qj+PMFX05xubzRyF76CCSJu8au9jgVxDV1+okFvgZU4A==",
+                        "dev": true,
+                        "license": "MIT",
+                        "dependencies": {
+                                "@types/hast": "^3.0.0",
+                                "@types/unist": "^3.0.0",
+                                "devlop": "^1.0.0",
+                                "hastscript": "^9.0.0",
+                                "property-information": "^6.0.0",
+                                "vfile": "^6.0.0",
+                                "vfile-location": "^5.0.0",
+                                "web-namespaces": "^2.0.0"
+                        },
+                        "funding": {
+                                "type": "opencollective",
+                                "url": "https://opencollective.com/unified"
+                        }
+                },
+                "node_modules/hast-util-parse-selector": {
+                        "version": "4.0.0",
+                        "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+                        "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+                        "dev": true,
+                        "license": "MIT",
+                        "dependencies": {
+                                "@types/hast": "^3.0.0"
+                        },
+                        "funding": {
+                                "type": "opencollective",
+                                "url": "https://opencollective.com/unified"
+                        }
+                },
+                "node_modules/hastscript": {
+                        "version": "9.0.0",
+                        "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.0.tgz",
+                        "integrity": "sha512-jzaLBGavEDKHrc5EfFImKN7nZKKBdSLIdGvCwDZ9TfzbF2ffXiov8CKE445L2Z1Ek2t/m4SKQ2j6Ipv7NyUolw==",
+                        "dev": true,
+                        "license": "MIT",
+                        "dependencies": {
+                                "@types/hast": "^3.0.0",
+                                "comma-separated-tokens": "^2.0.0",
+                                "hast-util-parse-selector": "^4.0.0",
+                                "property-information": "^6.0.0",
+                                "space-separated-tokens": "^2.0.0"
+                        },
+                        "funding": {
+                                "type": "opencollective",
+                                "url": "https://opencollective.com/unified"
+                        }
+                },
                 "node_modules/human-signals": {
                         "version": "2.1.0",
                         "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -1590,6 +1723,7 @@
                         "version": "2.0.1",
                         "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
                         "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+                        "dev": true,
                         "license": "MIT",
                         "funding": {
                                 "type": "github",
@@ -1600,6 +1734,7 @@
                         "version": "2.0.1",
                         "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
                         "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+                        "dev": true,
                         "license": "MIT",
                         "dependencies": {
                                 "is-alphabetical": "^2.0.0",
@@ -1626,6 +1761,7 @@
                         "version": "2.0.1",
                         "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
                         "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+                        "dev": true,
                         "license": "MIT",
                         "funding": {
                                 "type": "github",
@@ -1666,6 +1802,7 @@
                         "version": "2.0.1",
                         "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
                         "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+                        "dev": true,
                         "license": "MIT",
                         "funding": {
                                 "type": "github",
@@ -1797,6 +1934,7 @@
                         "version": "3.1.0",
                         "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
                         "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+                        "dev": true,
                         "funding": {
                                 "type": "github",
                                 "url": "https://github.com/sponsors/wooorm"
@@ -1842,6 +1980,7 @@
                         "version": "2.0.0",
                         "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.0.tgz",
                         "integrity": "sha512-n7MTOr/z+8NAX/wmhhDji8O3bRvPTV/U0oTCaZJkjhPSKTPhS3xufVhKGF8s1pJ7Ox4QgoIU7KHseh09S+9rTA==",
+                        "dev": true,
                         "dependencies": {
                                 "@types/mdast": "^4.0.0",
                                 "@types/unist": "^3.0.0",
@@ -1865,6 +2004,7 @@
                         "version": "3.0.0",
                         "resolved": "https://registry.npmjs.org/mdast-util-mdx/-/mdast-util-mdx-3.0.0.tgz",
                         "integrity": "sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w==",
+                        "dev": true,
                         "license": "MIT",
                         "dependencies": {
                                 "mdast-util-from-markdown": "^2.0.0",
@@ -1882,6 +2022,7 @@
                         "version": "2.0.1",
                         "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
                         "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+                        "dev": true,
                         "license": "MIT",
                         "dependencies": {
                                 "@types/estree-jsx": "^1.0.0",
@@ -1900,6 +2041,7 @@
                         "version": "3.1.3",
                         "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.1.3.tgz",
                         "integrity": "sha512-bfOjvNt+1AcbPLTFMFWY149nJz0OjmewJs3LQQ5pIyVGxP4CdOqNVJL6kTaM5c68p8q82Xv3nCyFfUnuEcH3UQ==",
+                        "dev": true,
                         "license": "MIT",
                         "dependencies": {
                                 "@types/estree-jsx": "^1.0.0",
@@ -1924,6 +2066,7 @@
                         "version": "2.0.1",
                         "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
                         "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+                        "dev": true,
                         "license": "MIT",
                         "dependencies": {
                                 "@types/estree-jsx": "^1.0.0",
@@ -1942,6 +2085,7 @@
                         "version": "4.1.0",
                         "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
                         "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+                        "dev": true,
                         "dependencies": {
                                 "@types/mdast": "^4.0.0",
                                 "unist-util-is": "^6.0.0"
@@ -1955,6 +2099,7 @@
                         "version": "2.1.0",
                         "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.0.tgz",
                         "integrity": "sha512-SR2VnIEdVNCJbP6y7kVTJgPLifdr8WEU440fQec7qHoHOUz/oJ2jmNRqdDQ3rbiStOXb2mCDGTuwsK5OPUgYlQ==",
+                        "dev": true,
                         "dependencies": {
                                 "@types/mdast": "^4.0.0",
                                 "@types/unist": "^3.0.0",
@@ -1974,6 +2119,7 @@
                         "version": "4.0.0",
                         "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
                         "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+                        "dev": true,
                         "dependencies": {
                                 "@types/mdast": "^4.0.0"
                         },
@@ -1981,6 +2127,13 @@
                                 "type": "opencollective",
                                 "url": "https://opencollective.com/unified"
                         }
+                },
+                "node_modules/mdn-data": {
+                        "version": "2.12.2",
+                        "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+                        "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+                        "dev": true,
+                        "license": "CC0-1.0"
                 },
                 "node_modules/merge-stream": {
                         "version": "2.0.0",
@@ -2001,6 +2154,7 @@
                         "version": "4.0.0",
                         "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.0.tgz",
                         "integrity": "sha512-o/sd0nMof8kYff+TqcDx3VSrgBTcZpSvYcAHIfHhv5VAuNmisCxjhx6YmxS8PFEpb9z5WKWKPdzf0jM23ro3RQ==",
+                        "dev": true,
                         "funding": [
                                 {
                                         "type": "GitHub Sponsors",
@@ -2035,6 +2189,7 @@
                         "version": "2.0.0",
                         "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.0.tgz",
                         "integrity": "sha512-jThOz/pVmAYUtkroV3D5c1osFXAMv9e0ypGDOIZuCeAe91/sD6BoE2Sjzt30yuXtwOYUmySOhMas/PVyh02itA==",
+                        "dev": true,
                         "funding": [
                                 {
                                         "type": "GitHub Sponsors",
@@ -2068,6 +2223,7 @@
                         "version": "3.0.0",
                         "resolved": "https://registry.npmjs.org/micromark-extension-mdx-expression/-/micromark-extension-mdx-expression-3.0.0.tgz",
                         "integrity": "sha512-sI0nwhUDz97xyzqJAbHQhp5TfaxEvZZZ2JDqUo+7NvyIYG6BZ5CPPqj2ogUoPJlmXHBnyZUzISg9+oUmU6tUjQ==",
+                        "dev": true,
                         "funding": [
                                 {
                                         "type": "GitHub Sponsors",
@@ -2094,6 +2250,7 @@
                         "version": "3.0.1",
                         "resolved": "https://registry.npmjs.org/micromark-extension-mdx-jsx/-/micromark-extension-mdx-jsx-3.0.1.tgz",
                         "integrity": "sha512-vNuFb9czP8QCtAQcEJn0UJQJZA8Dk6DXKBqx+bg/w0WGuSxDxNr7hErW89tHUY31dUW4NqEOWwmEUNhjTFmHkg==",
+                        "dev": true,
                         "license": "MIT",
                         "dependencies": {
                                 "@types/acorn": "^4.0.0",
@@ -2117,6 +2274,7 @@
                         "version": "2.0.0",
                         "resolved": "https://registry.npmjs.org/micromark-extension-mdx-md/-/micromark-extension-mdx-md-2.0.0.tgz",
                         "integrity": "sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ==",
+                        "dev": true,
                         "license": "MIT",
                         "dependencies": {
                                 "micromark-util-types": "^2.0.0"
@@ -2130,6 +2288,7 @@
                         "version": "3.0.0",
                         "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs/-/micromark-extension-mdxjs-3.0.0.tgz",
                         "integrity": "sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ==",
+                        "dev": true,
                         "license": "MIT",
                         "dependencies": {
                                 "acorn": "^8.0.0",
@@ -2150,6 +2309,7 @@
                         "version": "3.0.0",
                         "resolved": "https://registry.npmjs.org/micromark-extension-mdxjs-esm/-/micromark-extension-mdxjs-esm-3.0.0.tgz",
                         "integrity": "sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==",
+                        "dev": true,
                         "license": "MIT",
                         "dependencies": {
                                 "@types/estree": "^1.0.0",
@@ -2171,6 +2331,7 @@
                         "version": "2.0.0",
                         "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.0.tgz",
                         "integrity": "sha512-j9DGrQLm/Uhl2tCzcbLhy5kXsgkHUrjJHg4fFAeoMRwJmJerT9aw4FEhIbZStWN8A3qMwOp1uzHr4UL8AInxtA==",
+                        "dev": true,
                         "funding": [
                                 {
                                         "type": "GitHub Sponsors",
@@ -2191,6 +2352,7 @@
                         "version": "2.0.0",
                         "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.0.tgz",
                         "integrity": "sha512-RR3i96ohZGde//4WSe/dJsxOX6vxIg9TimLAS3i4EhBAFx8Sm5SmqVfR8E87DPSR31nEAjZfbt91OMZWcNgdZw==",
+                        "dev": true,
                         "funding": [
                                 {
                                         "type": "GitHub Sponsors",
@@ -2212,6 +2374,7 @@
                         "version": "2.0.2",
                         "resolved": "https://registry.npmjs.org/micromark-factory-mdx-expression/-/micromark-factory-mdx-expression-2.0.2.tgz",
                         "integrity": "sha512-5E5I2pFzJyg2CtemqAbcyCktpHXuJbABnsb32wX2U8IQKhhVFBqkcZR5LRm1WVoFqa4kTueZK4abep7wdo9nrw==",
+                        "dev": true,
                         "funding": [
                                 {
                                         "type": "GitHub Sponsors",
@@ -2239,6 +2402,7 @@
                         "version": "2.0.0",
                         "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.0.tgz",
                         "integrity": "sha512-TKr+LIDX2pkBJXFLzpyPyljzYK3MtmllMUMODTQJIUfDGncESaqB90db9IAUcz4AZAJFdd8U9zOp9ty1458rxg==",
+                        "dev": true,
                         "funding": [
                                 {
                                         "type": "GitHub Sponsors",
@@ -2258,6 +2422,7 @@
                         "version": "2.0.0",
                         "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.0.tgz",
                         "integrity": "sha512-jY8CSxmpWLOxS+t8W+FG3Xigc0RDQA9bKMY/EwILvsesiRniiVMejYTE4wumNc2f4UbAa4WsHqe3J1QS1sli+A==",
+                        "dev": true,
                         "funding": [
                                 {
                                         "type": "GitHub Sponsors",
@@ -2279,6 +2444,7 @@
                         "version": "2.0.0",
                         "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.0.tgz",
                         "integrity": "sha512-28kbwaBjc5yAI1XadbdPYHX/eDnqaUFVikLwrO7FDnKG7lpgxnvk/XGRhX/PN0mOZ+dBSZ+LgunHS+6tYQAzhA==",
+                        "dev": true,
                         "funding": [
                                 {
                                         "type": "GitHub Sponsors",
@@ -2300,6 +2466,7 @@
                         "version": "2.1.0",
                         "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.0.tgz",
                         "integrity": "sha512-KvOVV+X1yLBfs9dCBSopq/+G1PcgT3lAK07mC4BzXi5E7ahzMAF8oIupDDJ6mievI6F+lAATkbQQlQixJfT3aQ==",
+                        "dev": true,
                         "funding": [
                                 {
                                         "type": "GitHub Sponsors",
@@ -2319,6 +2486,7 @@
                         "version": "2.0.0",
                         "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.0.tgz",
                         "integrity": "sha512-anK8SWmNphkXdaKgz5hJvGa7l00qmcaUQoMYsBwDlSKFKjc6gjGXPDw3FNL3Nbwq5L8gE+RCbGqTw49FK5Qyvg==",
+                        "dev": true,
                         "funding": [
                                 {
                                         "type": "GitHub Sponsors",
@@ -2337,6 +2505,7 @@
                         "version": "2.0.0",
                         "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.0.tgz",
                         "integrity": "sha512-S0ze2R9GH+fu41FA7pbSqNWObo/kzwf8rN/+IGlW/4tC6oACOs8B++bh+i9bVyNnwCcuksbFwsBme5OCKXCwIw==",
+                        "dev": true,
                         "funding": [
                                 {
                                         "type": "GitHub Sponsors",
@@ -2357,6 +2526,7 @@
                         "version": "2.0.0",
                         "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.0.tgz",
                         "integrity": "sha512-vZZio48k7ON0fVS3CUgFatWHoKbbLTK/rT7pzpJ4Bjp5JjkZeasRfrS9wsBdDJK2cJLHMckXZdzPSSr1B8a4oQ==",
+                        "dev": true,
                         "funding": [
                                 {
                                         "type": "GitHub Sponsors",
@@ -2376,6 +2546,7 @@
                         "version": "2.0.1",
                         "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.1.tgz",
                         "integrity": "sha512-bmkNc7z8Wn6kgjZmVHOX3SowGmVdhYS7yBpMnuMnPzDq/6xwVA604DuOXMZTO1lvq01g+Adfa0pE2UKGlxL1XQ==",
+                        "dev": true,
                         "funding": [
                                 {
                                         "type": "GitHub Sponsors",
@@ -2394,6 +2565,7 @@
                         "version": "2.0.0",
                         "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.0.tgz",
                         "integrity": "sha512-r4Sc6leeUTn3P6gk20aFMj2ntPwn6qpDZqWvYmAG6NgvFTIlj4WtrAudLi65qYoaGdXYViXYw2pkmn7QnIFasA==",
+                        "dev": true,
                         "funding": [
                                 {
                                         "type": "GitHub Sponsors",
@@ -2415,6 +2587,7 @@
                         "version": "2.0.0",
                         "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.0.tgz",
                         "integrity": "sha512-pS+ROfCXAGLWCOc8egcBvT0kf27GoWMqtdarNfDcjb6YLuV5cM3ioG45Ys2qOVqeqSbjaKg72vU+Wby3eddPsA==",
+                        "dev": true,
                         "funding": [
                                 {
                                         "type": "GitHub Sponsors",
@@ -2430,6 +2603,7 @@
                         "version": "2.0.2",
                         "resolved": "https://registry.npmjs.org/micromark-util-events-to-acorn/-/micromark-util-events-to-acorn-2.0.2.tgz",
                         "integrity": "sha512-Fk+xmBrOv9QZnEDguL9OI9/NQQp6Hz4FuQ4YmCb/5V7+9eAh1s6AYSvL20kHkD67YIg7EpE54TiSlcsf3vyZgA==",
+                        "dev": true,
                         "funding": [
                                 {
                                         "type": "GitHub Sponsors",
@@ -2456,6 +2630,7 @@
                         "version": "2.0.0",
                         "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.0.tgz",
                         "integrity": "sha512-xNn4Pqkj2puRhKdKTm8t1YHC/BAjx6CEwRFXntTaRf/x16aqka6ouVoutm+QdkISTlT7e2zU7U4ZdlDLJd2Mcw==",
+                        "dev": true,
                         "funding": [
                                 {
                                         "type": "GitHub Sponsors",
@@ -2471,6 +2646,7 @@
                         "version": "2.0.0",
                         "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.0.tgz",
                         "integrity": "sha512-2xhYT0sfo85FMrUPtHcPo2rrp1lwbDEEzpx7jiH2xXJLqBuy4H0GgXk5ToU8IEwoROtXuL8ND0ttVa4rNqYK3w==",
+                        "dev": true,
                         "funding": [
                                 {
                                         "type": "GitHub Sponsors",
@@ -2489,6 +2665,7 @@
                         "version": "2.0.0",
                         "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.0.tgz",
                         "integrity": "sha512-6KU6qO7DZ7GJkaCgwBNtplXCvGkJToU86ybBAUdavvgsCiG8lSSvYxr9MhwmQ+udpzywHsl4RpGJsYWG1pDOcA==",
+                        "dev": true,
                         "funding": [
                                 {
                                         "type": "GitHub Sponsors",
@@ -2507,6 +2684,7 @@
                         "version": "2.0.0",
                         "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.0.tgz",
                         "integrity": "sha512-WhYv5UEcZrbAtlsnPuChHUAsu/iBPOVaEVsntLBIdpibO0ddy8OzavZz3iL2xVvBZOpolujSliP65Kq0/7KIYw==",
+                        "dev": true,
                         "funding": [
                                 {
                                         "type": "GitHub Sponsors",
@@ -2527,6 +2705,7 @@
                         "version": "2.0.0",
                         "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.0.0.tgz",
                         "integrity": "sha512-vc93L1t+gpR3p8jxeVdaYlbV2jTYteDje19rNSS/H5dlhxUYll5Fy6vJ2cDwP8RnsXi818yGty1ayP55y3W6fg==",
+                        "dev": true,
                         "funding": [
                                 {
                                         "type": "GitHub Sponsors",
@@ -2548,6 +2727,7 @@
                         "version": "2.0.0",
                         "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.0.tgz",
                         "integrity": "sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==",
+                        "dev": true,
                         "funding": [
                                 {
                                         "type": "GitHub Sponsors",
@@ -2563,6 +2743,7 @@
                         "version": "2.0.0",
                         "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.0.tgz",
                         "integrity": "sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w==",
+                        "dev": true,
                         "funding": [
                                 {
                                         "type": "GitHub Sponsors",
@@ -2635,7 +2816,8 @@
                 "node_modules/ms": {
                         "version": "2.1.2",
                         "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                        "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+                        "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                        "dev": true
                 },
                 "node_modules/mz": {
                         "version": "2.7.0",
@@ -2715,6 +2897,7 @@
                         "version": "4.0.2",
                         "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
                         "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+                        "dev": true,
                         "license": "MIT",
                         "dependencies": {
                                 "@types/unist": "^2.0.0",
@@ -2734,7 +2917,21 @@
                         "version": "2.0.11",
                         "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
                         "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+                        "dev": true,
                         "license": "MIT"
+                },
+                "node_modules/parse5": {
+                        "version": "7.2.1",
+                        "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
+                        "integrity": "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==",
+                        "dev": true,
+                        "license": "MIT",
+                        "dependencies": {
+                                "entities": "^4.5.0"
+                        },
+                        "funding": {
+                                "url": "https://github.com/inikulin/parse5?sponsor=1"
+                        }
                 },
                 "node_modules/path-key": {
                         "version": "3.1.1",
@@ -2912,6 +3109,17 @@
                                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
                         }
                 },
+                "node_modules/property-information": {
+                        "version": "6.5.0",
+                        "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.5.0.tgz",
+                        "integrity": "sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig==",
+                        "dev": true,
+                        "license": "MIT",
+                        "funding": {
+                                "type": "github",
+                                "url": "https://github.com/sponsors/wooorm"
+                        }
+                },
                 "node_modules/punycode": {
                         "version": "2.3.1",
                         "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2979,6 +3187,7 @@
                         "version": "3.1.0",
                         "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-3.1.0.tgz",
                         "integrity": "sha512-Ngl/H3YXyBV9RcRNdlYsZujAmhsxwzxpDzpDEhFBVAGthS4GDgnctpDjgFl/ULx5UEDzqtW1cyBSNKqYYrqLBA==",
+                        "dev": true,
                         "license": "MIT",
                         "dependencies": {
                                 "mdast-util-mdx": "^3.0.0",
@@ -3157,6 +3366,17 @@
                                 "node": ">=0.10.0"
                         }
                 },
+                "node_modules/space-separated-tokens": {
+                        "version": "2.0.2",
+                        "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+                        "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+                        "dev": true,
+                        "license": "MIT",
+                        "funding": {
+                                "type": "github",
+                                "url": "https://github.com/sponsors/wooorm"
+                        }
+                },
                 "node_modules/stackback": {
                         "version": "0.0.2",
                         "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -3232,6 +3452,7 @@
                         "version": "4.0.4",
                         "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
                         "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+                        "dev": true,
                         "license": "MIT",
                         "dependencies": {
                                 "character-entities-html4": "^2.0.0",
@@ -3581,6 +3802,7 @@
                         "version": "2.0.0",
                         "resolved": "https://registry.npmjs.org/unist-util-position-from-estree/-/unist-util-position-from-estree-2.0.0.tgz",
                         "integrity": "sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ==",
+                        "dev": true,
                         "license": "MIT",
                         "dependencies": {
                                 "@types/unist": "^3.0.0"
@@ -3594,6 +3816,7 @@
                         "version": "4.0.0",
                         "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
                         "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+                        "dev": true,
                         "dependencies": {
                                 "@types/unist": "^3.0.0"
                         },
@@ -3650,10 +3873,26 @@
                                 "url": "https://opencollective.com/unified"
                         }
                 },
+                "node_modules/vfile-location": {
+                        "version": "5.0.3",
+                        "resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-5.0.3.tgz",
+                        "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+                        "dev": true,
+                        "license": "MIT",
+                        "dependencies": {
+                                "@types/unist": "^3.0.0",
+                                "vfile": "^6.0.0"
+                        },
+                        "funding": {
+                                "type": "opencollective",
+                                "url": "https://opencollective.com/unified"
+                        }
+                },
                 "node_modules/vfile-message": {
                         "version": "4.0.2",
                         "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
                         "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
+                        "dev": true,
                         "dependencies": {
                                 "@types/unist": "^3.0.0",
                                 "unist-util-stringify-position": "^4.0.0"
@@ -3939,6 +4178,17 @@
                                 "url": "https://github.com/sponsors/sindresorhus"
                         }
                 },
+                "node_modules/web-namespaces": {
+                        "version": "2.0.1",
+                        "resolved": "https://registry.npmjs.org/web-namespaces/-/web-namespaces-2.0.1.tgz",
+                        "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+                        "dev": true,
+                        "license": "MIT",
+                        "funding": {
+                                "type": "github",
+                                "url": "https://github.com/sponsors/wooorm"
+                        }
+                },
                 "node_modules/webidl-conversions": {
                         "version": "4.0.2",
                         "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
@@ -4103,6 +4353,7 @@
                         "version": "2.0.4",
                         "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
                         "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+                        "dev": true,
                         "funding": {
                                 "type": "github",
                                 "url": "https://github.com/sponsors/wooorm"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
         "author": "Dheepak Krishnamurthy",
         "license": "MIT",
         "devDependencies": {
+                "hast-util-from-html": "^2.0.0",
+                "mdast-util-mdx-jsx": "^3.1.0",
                 "remark": "^15.0.1",
                 "remark-mdx": "^3.1.0",
                 "ts-node": "^10.9.2",

--- a/src/remarkPlugin.ts
+++ b/src/remarkPlugin.ts
@@ -1,35 +1,87 @@
 import { visit } from "unist-util-visit";
 import type { Node } from "unist";
 import { getRenderer } from "./svgbob-wasm";
-import { Buffer } from "node:buffer";
+import { fromHtml } from 'hast-util-from-html'
+import { MdxJsxAttribute, MdxJsxFlowElement } from 'mdast-util-mdx-jsx'
+import { Root, Element as HASTElement, Text as HASTText, Properties, RootContent} from "hast";
 
 interface CodeNode extends Node {
   lang?: string;
   value: string;
 }
 
+// Convert HAST attributes into MdxJsx attributes
+function processHastAttributes(properties: Properties) : MdxJsxAttribute[] {
+  function get_value_as_string(key) : string {
+    let value = properties[key];
+    if(value instanceof Array) {
+      return value.map((v) => v.toString()).join(" ");
+    }
+    else if(typeof value === "number") {
+      return properties[key].toString();
+    }
+    else if (typeof value === "string") {
+      return properties[key] as string;
+    }
+  };
+
+  return Object.keys(properties).map((key) => {
+    return {
+      type: "mdxJsxAttribute",
+      name: key,
+      value: get_value_as_string(key),
+    }
+  });
+}
+
+function isElement(node: RootContent) : node is HASTElement {
+  return node?.type == "element";
+}
+
+function isText(node: RootContent) : node is HASTText {
+  return node?.type == "text";
+}
+
+function processHastElement(node: RootContent) : MdxJsxFlowElement | undefined {
+  let ret = undefined;
+  if(isElement(node)) {
+    // Deal with text nodes seperately so that we don't recursively place whitespace only 
+    // nodes in the output tree which will litter the html with empty <text> nodes.
+    if(node.tagName === "text" && node?.children.length == 1 && isText(node.children[0])) { 
+      ret = {
+        type: "mdxJsxFlowElement",
+        name: node.tagName,
+        attributes: processHastAttributes(node.properties),
+        children: [{type: "text", value: node.children[0].value}],
+      }
+    } else {
+      ret = {
+        type: "mdxJsxFlowElement",
+        name: node.tagName,
+        attributes: processHastAttributes(node.properties),
+        children: node?.children.map((child) => processHastElement(child)).filter((n) => n!=undefined) || [],
+      }
+    }
+  }
+
+  return ret;
+}
+
+
 export const remarkPlugin = () => {
   return async function transformer(tree: Node): Promise<Node> {
     const render = await getRenderer();
-    // Create an array to hold all of the images from the markdown file
 
     visit(tree, "code", (node: CodeNode, index: any, parent: any) => {
       if (node.lang === "svgbob") {
         const svg = render(node.value);
-        const buffer = Buffer.from(svg, "utf8");
-        const base64SVG = buffer.toString("base64");
-        const imgSrc = `data:image/svg+xml;base64,${base64SVG}`;
-
-        const image = {
-          type: "mdxJsxFlowElement",
-          name: "img",
-          attributes: [
-            { type: "mdxJsxAttribute", name: "src", value: imgSrc },
-            { type: "mdxJsxAttribute", name: "alt", value: "svgbob" },
-          ],
-          children: [],
-        };
-
+        // Convert into hast format
+        let hast : Root = fromHtml(svg, {fragment: true});
+        // The first (and only) child of the root node will an svg element
+        let element = hast.children[0];
+        // Recursively process the elements into mdxJsxFlowElements
+        let image : MdxJsxFlowElement = processHastElement(element);
+        // Replace the code node with the image node
         parent.children.splice(index, 1, image);
       }
     });
@@ -37,3 +89,4 @@ export const remarkPlugin = () => {
     return tree;
   };
 };
+

--- a/src/svgbob.css
+++ b/src/svgbob.css
@@ -1,0 +1,77 @@
+.svgbob line, .svgbob path, .svgbob circle, .svgbob rect, .svgbob polygon {
+    stroke: white;
+    stroke-width: 2;
+    stroke-opacity: 1;
+    fill-opacity: 1;
+    stroke-linecap: round;
+    stroke-linejoin: miter;
+  }
+  
+  .svgbob text {
+    white-space: pre;
+    fill: white;
+    font-family: Iosevka Fixed, monospace;
+    font-size: 14px;
+  }
+  
+  .svgbob rect.backdrop {
+    stroke: none;
+    fill: transparent;
+  }
+  
+  .svgbob .broken {
+    stroke-dasharray: 8;
+  }
+  
+  .svgbob .filled {
+    fill: white;
+  }
+  
+  .svgbob .bg_filled {
+    fill: transparent;
+    stroke-width: 1;
+  }
+  
+  .svgbob .nofill {
+    fill: transparent;
+  }
+  
+  .svgbob .end_marked_arrow {
+    marker-end: url(#arrow);
+  }
+  
+  .svgbob .start_marked_arrow {
+    marker-start: url(#arrow);
+  }
+  
+  .svgbob .end_marked_diamond {
+    marker-end: url(#diamond);
+  }
+  
+  .svgbob .start_marked_diamond {
+    marker-start: url(#diamond);
+  }
+  
+  .svgbob .end_marked_circle {
+    marker-end: url(#circle);
+  }
+  
+  .svgbob .start_marked_circle {
+    marker-start: url(#circle);
+  }
+  
+  .svgbob .end_marked_open_circle {
+    marker-end: url(#open_circle);
+  }
+  
+  .svgbob .start_marked_open_circle {
+    marker-start: url(#open_circle);
+  }
+  
+  .svgbob .end_marked_big_open_circle {
+    marker-end: url(#big_open_circle);
+  }
+  
+  .svgbob .start_marked_big_open_circle {
+    marker-start: url(#big_open_circle);
+  }


### PR DESCRIPTION
Generate inline SVG without the need for inserting a 'raw' node. It removes the inline base64 encoded SVG in a <img> tag as this did now allow style variations. The css styling has been removed from the embedded SVG to enable site-wide control of the svgbob styling. This allows for dealing with cases such as dark mode etc

Examples of the same svgbob image, styled in normal and dark mode:
![image_light](https://github.com/user-attachments/assets/022fad90-060b-421f-bb30-1c469d222caf)


![image_dark](https://github.com/user-attachments/assets/3ab30d9c-b924-4053-a4cd-3294e50c9914)

This example is using tailwind in a nextjs app by replacing the instances of `white` in `svgbob.css` with `var(--foreground)`.

Signed-off-by: Matt Spencer matthew@thespencers.me.uk